### PR TITLE
using fetch/copy to distribute munge.key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ Create an inventory file, copying structure of:
 
 The playbook attempts to do this for you.
 
-!WARNING!: There is a task that uses `rsync` to synchronise the munge key file
-from the slurm server to the slurm worker nodes. This will only work is passwordless
-SSH is possible from the slurm server to the worker nodes.
 
 ## Test Slurm is working
 
@@ -50,7 +47,6 @@ Use the `Vagrantfile` to setup up a cluster:
 
 ```
 $ vagrant up
-$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u vagrant --private-key=~/.vagrant.d/insecure_private_key -i inventories/vagrant-cluster setup-vagrant-hosts-playbook.yml
-$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u vagrant --private-key=~/.vagrant.d/insecure_private_key -i inventories/vagrant-cluster playbook-cluster.yml
+$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u vagrant --private-key=~/.vagrant.d/insecure_private_key -i inventories/vagrant-cluster.yml playbook.yml
 $ vagrant ssh slurmmaster
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,14 @@ Vagrant.require_version ">= 1.7.0"
 Vagrant.configure("2") do |config|
 
 #######################################
-### WPS Servers  ######################
+### slurm nodes  ######################
 #######################################
+
+  # Increased memory (default: 512) to resolve conda envs in jaspy (21/06/2019)
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--cpus", 2]
+  end
 
   # Disable the new default behavior introduced in Vagrant 1.7, to
   # ensure that all Vagrant machines will use the same SSH key pair.

--- a/group_vars/all
+++ b/group_vars/all
@@ -10,12 +10,14 @@ slurm_wn_cpus: 1
 slurm_user: slurm
 slurm_user_id: 5001
 
+# Local directory to store munge and slurm server files
+# - copied from master server back to deployment host and shared with worker nodes
+local_slurm_cache: ./slurm-cache
+
 # Slurm log file locations
 slurmctld_log: /var/log/slurm/slurmctld.log
 slurmd_log: /var/log/slurm/slurmd.log
 
 # Flag to download remote RPMs
-download_remote_rpms: true 
+download_remote_rpms: true
 rpm_base_url: http://home.badc.rl.ac.uk/astephens/rpms/
-
-

--- a/roles/munge/tasks/front.yaml
+++ b/roles/munge/tasks/front.yaml
@@ -5,7 +5,7 @@
     notify: restart munge
 
   - name: Generate munge key with password
-    shell: echo -n "{{ munge_key_password }}" | sha512sum | cut -d' ' -f1 
+    shell: echo -n "{{ munge_key_password }}" | sha512sum | cut -d' ' -f1
     when: munge_key_password != ''
     register: key_content
     changed_when: false
@@ -13,6 +13,12 @@
   - name: Create munge.key file with password
     copy: content="{{ key_content.stdout }}" dest=/etc/munge/munge.key mode=0400 owner=munge
     when: munge_key_password != ''
+
+  - name: copy munge.key from server to local cache
+    fetch:
+      src: "/etc/munge/munge.key"
+      dest: "{{ local_slurm_cache }}/munge.key"
+      flat: yes
 
   - name: Restart Munge service
     service: name=munge state=restarted

--- a/roles/munge/tasks/main.yml
+++ b/roles/munge/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+  - name: remove old cache
+    command: rm -fr "{{ local_slurm_cache }}"
+    when: munge_type_of_node == "front"
+
+  - name: check local slurm-cache exists
+    command: mkdir -p "{{ local_slurm_cache }}"
+
   - name: Start Munge service
     service: name=munge state=started
     register: munge_installed

--- a/roles/munge/tasks/wn.yaml
+++ b/roles/munge/tasks/wn.yaml
@@ -1,10 +1,15 @@
 ---
 
-  - name: synchronise the munge.key from master node to the worker node (rsync push)
-    synchronize:
-      src: "/etc/munge/munge.key"
+  - name: check local slurm cache directory exists
+    stat: path="{{ local_slurm_cache }}/munge.key"
+
+  - name: copy munge.key file to the slurm worker node
+    copy:
+      src: "{{ local_slurm_cache }}/munge.key"
       dest: "/etc/munge/munge.key"
-    delegate_to: "{{ slurm_server_name }}"
+      owner: munge
+      group: munge
+      mode: '0400'
 
   - name: Restart Munge service
     service: name=munge state=restarted

--- a/roles/slurm/tasks/front.yaml
+++ b/roles/slurm/tasks/front.yaml
@@ -5,6 +5,12 @@
   - name: Include slurm config recipe
     include: "config_file.yaml"
 
+  - name: copy the slurm.conf from server to local cache
+    fetch:
+      src: "{{ SLURM_CONF }}"
+      dest: "{{ local_slurm_cache }}/slurm.conf"
+      flat: yes
+
   - name: Start SLURM service
     become: true
     become_user: slurm
@@ -19,6 +25,5 @@
     become_user: slurm
     command: scontrol reconfigure
 
-  - name: allow the slurm user to acces the slurm logs
+  - name: allow the slurm user to access the slurm logs
     file: path={{ slurmctld_log }} mode=0644
-

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -6,6 +6,9 @@
   - stat: path={{ SRUN_PATH }}
     register: slurm_installed
 
+  - name: make local slurm cache directory
+    command: mkdir -p {{ local_slurm_cache }}
+
   - name: Install epel repo
     yum: name=epel-release,yum-priorities
 

--- a/roles/slurm/tasks/wn.yaml
+++ b/roles/slurm/tasks/wn.yaml
@@ -7,6 +7,17 @@
   - name: Include slurm config recipe
     include: "config_file.yaml"
 
+  - name: check local slurm cache directory exists
+    stat: path="{{ local_slurm_cache }}/slurm.conf"
+
+  - name: copy slurm.conf file from the frontend
+    copy:
+      src: "{{ local_slurm_cache }}/slurm.conf"
+      dest: /etc/slurm/slurm.conf
+      owner: 'slurm'
+      group: 'slurm'
+      mode: '0644'
+
   - name: Start Slurm Daemon
     command: slurmd
 
@@ -15,4 +26,3 @@
 
   - name: allow the slurm user to acces the slurm logs
     file: path={{ slurmd_log }} mode=0644
-

--- a/roles/vm_config/tasks/main.yml
+++ b/roles/vm_config/tasks/main.yml
@@ -8,13 +8,3 @@
     - "{{ etc_hosts_entries }}"
   when:
     - (etc_hosts_entries is defined)
-
-- name: copy across id_rsa file
-  copy:
-    src:  /root/.ssh/id_rsa
-    dest: /root/.ssh/id_rsa
-    owner: root
-    group: root
-    mode: '0400'
-  when:
-    - (etc_hosts_entries is defined)


### PR DESCRIPTION
This PR adds the fetch/copy method to distribute the `munge.key` and the `slurm.conf` to the worker nodes. It removes the `rsync` approach.