### PR TITLE
using .local as shared folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.local_cache
+.local
 .vagrant
 *.log

--- a/group_vars/all
+++ b/group_vars/all
@@ -12,7 +12,7 @@ slurm_user_id: 5001
 
 # Local path to copy across munge key to, so it can be copied from
 # the master server and then copied to the worker nodes
-local_munge_key: .local_cache/tmp_munge_key
+local_munge_key: .local/cache/tmp_munge_key
 
 # Slurm log file locations
 slurmctld_log: /var/log/slurm/slurmctld.log


### PR DESCRIPTION
... using `.local` as shared folder in Vagrant VMs.